### PR TITLE
Log job id for jobs that are scheduled to run in the future

### DIFF
--- a/lib/sidekiq/repeat/repeatable.rb
+++ b/lib/sidekiq/repeat/repeatable.rb
@@ -31,8 +31,8 @@ module Sidekiq
               Sidekiq.logger.info "Re-scheduled #{self.name} for #{ts}."
             end
           else
-            self.perform_at ts.to_f, *args
-            Sidekiq.logger.info "Scheduled #{self.name} for #{ts}."
+            jid = self.perform_at ts.to_f, *args
+            Sidekiq.logger.info "Scheduled #{self.name} for #{ts} with jid `#{jid.inspect}`."
           end
         end
 


### PR DESCRIPTION
This should help debugging cases in which a repeatable job vanishes from redis/sidekiq and is not executed anymore. We have the hunch that the enqueuing of the job is aborted by a middleware, if this is the case we will see the `jid` being logged as `nil`.